### PR TITLE
fix: release configuration

### DIFF
--- a/flavours/release-package.js
+++ b/flavours/release-package.js
@@ -1,6 +1,20 @@
 module.exports = {
-  extends: ['./release.js'],
+  branches: ['main'],
   plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    [
+      '@semantic-release/changelog',
+      {
+        changelogFile: 'docs/CHANGELOG.md',
+      },
+    ],
+    [
+      '@semantic-release/github',
+      {
+        assets: [{ path: 'pack/*.tgz', label: 'Release' }],
+      },
+    ],
     [
       '@semantic-release/npm',
       {


### PR DESCRIPTION
- add default plugins to `release-package` (since they don't get included when extending a config)