### PR TITLE
fix: add @semantic-release/npm

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,7 @@ runs:
           @semantic-release/release-notes-generator \
           @semantic-release/changelog \
           @semantic-release/github \
+          @semantic-release/npm \
           conventional-changelog-conventionalcommits@4.5.0
       shell: bash
     - run: |


### PR DESCRIPTION
Should have realised this sooner, but the `release-package` workflow is using a package that we didn't install yet.