### PR TITLE
fix: lock semantic-release deps into specific versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,11 @@ runs:
   steps:
     - run: |
         yarn add \
-          @semantic-release/commit-analyzer \
-          @semantic-release/release-notes-generator \
-          @semantic-release/changelog \
-          @semantic-release/github \
-          @semantic-release/npm \
+          @semantic-release/commit-analyzer@8.0.1 \
+          @semantic-release/release-notes-generator@9.0.1 \
+          @semantic-release/changelog@5.0.1 \
+          @semantic-release/github@7.2.0 \
+          @semantic-release/npm@7.0.10 \
           conventional-changelog-conventionalcommits@4.5.0
       shell: bash
     - run: |


### PR DESCRIPTION
I've used the most recent versions here, which seem to be working OK. So if anyone ever injects some malicious code, we won't automatically use that update.