### PR TITLE
build: add back dependencies, but as devDeps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,15 @@ runs:
   using: "composite"
   steps:
     - run: |
+        yarn add -D \
+          @semantic-release/commit-analyzer@8.0.1 \
+          @semantic-release/release-notes-generator@9.0.1 \
+          @semantic-release/changelog@5.0.1 \
+          @semantic-release/github@7.2.0 \
+          @semantic-release/npm@7.0.10 \
+          conventional-changelog-conventionalcommits@4.5.0
+      shell: bash
+    - run: |
         npx semantic-release \
           --extends ${{ github.action_path }}/flavours/${{ inputs.flavour }}.js \
           --branches ${{ inputs.branches }} \

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - run: |
-        yarn add -D \
+        yarn add --ignore-scripts -D \
           @semantic-release/commit-analyzer@8.0.1 \
           @semantic-release/release-notes-generator@9.0.1 \
           @semantic-release/changelog@5.0.1 \


### PR DESCRIPTION
Since the build failed on `main` we have to go down this route. This should make the build pass again, and _not_ include those packages in any  of the releases it creates. 🙏 